### PR TITLE
Add functionality for filter text reset, reuse sprite.

### DIFF
--- a/client/html/templates/catalog/filter/search-body-default.php
+++ b/client/html/templates/catalog/filter/search-body-default.php
@@ -105,6 +105,11 @@ $suggestUrl = $enc->attr( $this->url( $suggestTarget, $suggestController, $sugge
 <section class="catalog-filter-search">
 	<h2><?php echo $enc->html( $this->translate( 'client', 'Search' ), $enc::TRUST ); ?></h2>
 	<input class="value" type="text" name="<?php echo $name; ?>" value="<?php echo $phrase; ?>" data-url="<?php echo $suggestUrl; ?>" data-hint="<?php echo $hint; ?>" /><!--
+    Comment end to prevent merge conflict and thus non-fast forward merge. -->
+	<div style="display: <?php if (empty($phrase)) echo 'none'; else echo 'inline-block'?>;" class="pp_default">
+		<span class="pp_close"></span>
+	</div>
+	<!-- Comment begin to prevent merge conflict and thus non-fast forward merge.
 	--><button class="standardbutton" type="submit"><?php echo $enc->html( $this->translate( 'client', 'Go' ), $enc::TRUST ); ?></button>
 <?php echo $this->get( 'searchBody' ); ?>
 </section>

--- a/client/html/themes/elegance/aimeos.css
+++ b/client/html/themes/elegance/aimeos.css
@@ -359,6 +359,22 @@
 	display: none;
 }
 
+.catalog-filter-search > div:nth-of-type(1) {
+	display: inline-block; /* show by default, toggled by jquery */
+	position: relative;
+	right: 25pt;
+}
+
+/* catalog filter search reset icon: */
+.catalog-filter-search div.pp_default .pp_close {
+	background: transparent url("media/prettyPhoto/default/sprite.png") no-repeat scroll -8px -7px;
+	cursor: pointer;
+	width: 10px;
+	height: 11px;
+	display: inline-block; /* Because width only takes effect for block elements. */
+}
+
+
 .catalog-filter .search-hint {
 	position: absolute;
 	background-color: #ffeeee;

--- a/client/html/themes/elegance/aimeos.js
+++ b/client/html/themes/elegance/aimeos.js
@@ -4,3 +4,41 @@
  * @license LGPLv3, http://opensource.org/licenses/LGPL-3.0
  * @copyright Aimeos (aimeos.org), 2014
  */
+
+
+
+/**
+ * Hides or shows the catalog filter search reset button
+ * depending on if the input text field is empty or not.
+ */
+hide_or_show_catalog_filter_search_reset_button: function() {
+	if (this.value !== '')
+		this.nextElementSibling.style.display = 'inline-block';
+	else
+		this.nextElementSibling.style.display = 'none';
+}
+
+
+
+/**
+ * Resets the currently catalog filter search.
+ * In the simplest case the entered search term was not submitted
+ * yet, such that the field is just cleared.
+ * The major purpose of this field is to reset the search without
+ * having to manually empty the input field and submit it to show
+ * all items of all categories again.
+ */
+reset_catalog_filter_search: function() {
+//	var catalog_filter_search_input = $('.catalog-filter-search input:nth-of-type(1)');
+//	catalog_filter_search_input.val('');
+	this.previousElementSibling.val('');
+	this.parentNode.parentNode.submit();
+	this.style.display = 'none';
+}
+
+
+
+/* Register events: */
+$('.catalog-filter-search input:nth-of-type(1)').on('keyup', hide_or_show_catalog_filter_search_reset_button);
+$('.catalog-filter-search div:nth-of-type(1)').on('click', reset_catalog_filter_search);
+


### PR DESCRIPTION
Add functionality for filter text reset, reuse sprite close button as
reset icon to the right in the search bar.

Alternatively one may use the Shop index direct link. This is not
implemented, yet it should be possible to manually press access the link.

Note: The translation domain must be correct or "Non-recoverable error
occurred" message appears. Exempli gratia at some point the key
client/html was changed to just client. Still having client/html then
leads to an error.

Also hide the cross if text filter input field is empty.