### PR TITLE
Add functionality for filter text reset, reuse sprite.

### DIFF
--- a/client/html/templates/catalog/filter/search-body-default.php
+++ b/client/html/templates/catalog/filter/search-body-default.php
@@ -105,6 +105,11 @@ $suggestUrl = $enc->attr( $this->url( $suggestTarget, $suggestController, $sugge
 <section class="catalog-filter-search">
 	<h2><?php echo $enc->html( $this->translate( 'client', 'Search' ), $enc::TRUST ); ?></h2>
 	<input class="value" type="text" name="<?php echo $name; ?>" value="<?php echo $phrase; ?>" data-url="<?php echo $suggestUrl; ?>" data-hint="<?php echo $hint; ?>" /><!--
+    Comment end to prevent merge conflict and thus non-fast forward merge. -->
+	<div class="pp_default">
+		<span class="pp_close"></span>
+	</div>
+	<!-- Comment begin to prevent merge conflict and thus non-fast forward merge.
 	--><button class="standardbutton" type="submit"><?php echo $enc->html( $this->translate( 'client', 'Go' ), $enc::TRUST ); ?></button>
 <?php echo $this->get( 'searchBody' ); ?>
 </section>

--- a/client/html/themes/elegance/aimeos.css
+++ b/client/html/themes/elegance/aimeos.css
@@ -359,6 +359,32 @@
 	display: none;
 }
 
+.catalog-filter-search > div:first-of-type {
+	display: inline-block; /* show by default, toggled by jquery */
+	position: relative;
+	right: 25pt;
+}
+
+/* Show text search reset icon by default: */
+.catalog-filter-search .value + .pp_default {
+	display: inline-block;
+}
+
+/* Hide text search reset icon when value is empty: */
+.catalog-filter-search .value[value=''] + .pp_default {
+	display: none;
+}
+
+/* catalog filter search reset icon: */
+.catalog-filter-search div.pp_default .pp_close {
+	background: transparent url("media/prettyPhoto/default/sprite.png") no-repeat scroll -8px -7px;
+	cursor: pointer;
+	width: 10px;
+	height: 11px;
+	display: inline-block; /* Because width only takes effect for block elements. */
+}
+
+
 .catalog-filter .search-hint {
 	position: absolute;
 	background-color: #ffeeee;

--- a/client/html/themes/elegance/aimeos.js
+++ b/client/html/themes/elegance/aimeos.js
@@ -4,3 +4,58 @@
  * @license LGPLv3, http://opensource.org/licenses/LGPL-3.0
  * @copyright Aimeos (aimeos.org), 2014
  */
+
+
+
+/**
+ * Hides or shows the catalog filter search reset button
+ * depending on if the input text field is empty or not.
+ */
+AimeosCatalogFilter.hideOrShowCatalogFilterTextSearchResetButton = function() {
+	if ($(this).val() !== '') {
+		$(this.nextElementSibling).css('display', 'inline-block');
+	}
+	else {
+		$(this.nextElementSibling).css('display', 'none');
+	}
+};
+
+
+
+/**
+ * Resets the currently catalog filter search.
+ * In the simplest case the entered search term was not submitted
+ * yet, such that the field is just cleared.
+ * The major purpose of this field is to reset the search without
+ * having to manually empty the input field and submit it to show
+ * all items of all categories again.
+ */
+AimeosCatalogFilter.resetCatalogFilterTextSearch = function() {
+//	var catalog_filter_search_input = $('.catalog-filter-search input:nth-of-type(1)');
+//	catalog_filter_search_input.val('');
+	$(this.previousElementSibling).val('');
+	//this.parentNode.parentNode.submit();
+	$(this).css('display', 'none');
+};
+
+
+
+/**
+ * Registers events for the catalog filter search input reset.
+ */
+AimeosCatalogFilter.setupCatalogFilterTextSearchReset = function() {
+	$('.catalog-filter-search input:first-of-type').on('keyup', AimeosCatalogFilter.hideOrShowCatalogFilterTextSearchResetButton);
+	$('.catalog-filter-search div:first-of-type').on('click', AimeosCatalogFilter.resetCatalogFilterTextSearch);
+};
+
+
+
+/**
+ * Initalize preserving existing init without duplicating code.
+ */
+AimeosCatalogFilter.init = (function(fcn) {
+	return function() {
+		fcn(this);
+		this.setupCatalogFilterTextSearchReset();
+	}
+})(AimeosCatalogFilter.init);


### PR DESCRIPTION
Add functionality for filter text reset, reuse sprite close button as
reset icon to the right in the search bar.

Alternatively one may use the Shop index direct link. This is not
implemented, yet it should be possible to manually press access the link.

Note: The translation domain must be correct or "Non-recoverable error
occurred" message appears. Exempli gratia at some point the key
client/html was changed to just client. Still having client/html then
leads to an error.

Also hide the cross if text filter input field is empty.