### PR TITLE
Search: Constantify magic number to allow reconfiguration of min input length.

### DIFF
--- a/client/html/themes/aimeos.js
+++ b/client/html/themes/aimeos.js
@@ -766,10 +766,13 @@ AimeosCatalog = {
 };
 
 
+
 /**
  * Catalog filter actions
  */
 AimeosCatalogFilter = {
+
+	MIN_INPUT_LEN: 3,
 
 	/**
 	 * Autocompleter for quick search
@@ -780,7 +783,7 @@ AimeosCatalogFilter = {
 
 		if(aimeosInputComplete.length) {
 			aimeosInputComplete.autocomplete({
-				minLength : 3,
+				minLength : AimeosCatalogFilter.MIN_INPUT_LEN,
 				delay : 200,
 				source : function(req, resp) {
 					var nameTerm = {};
@@ -815,7 +818,7 @@ AimeosCatalogFilter = {
 
 				var input = $(this);
 
-				if(input.val() !== '' && input.val().length < 3) {
+				if(input.val() !== '' && input.val().length < AimeosCatalogFilter.MIN_INPUT_LEN) {
 
 					if($(this).has(".search-hint").length === 0) {
 


### PR DESCRIPTION
Please tell me if I miss some magic numbers at other places or something else.
It is okay if you rather want to keep the `3` characters as minimum input for the `search text field`.

Reason for the reduction is that when e.g. entering code digits, it'd be nicer to only have to type 2 instead of 3 - especially when `product code` only has e.g. 4 characters in total.