### PR TITLE
schema.org: product image itemprop="image"

### DIFF
--- a/client/html/templates/catalog/detail/image-partial-bottom.php
+++ b/client/html/templates/catalog/detail/image-partial-bottom.php
@@ -66,7 +66,7 @@ $mediaItems = $this->get( 'mediaItems', [] );
 
 			<figure id="image-<?= $enc->attr( $id ); ?>"
 				class="item" style="background-image: url('<?= $mediaUrl; ?>')"
-				itemprop="associatedMedia" itemscope="" itemtype="http://schema.org/ImageObject"
+				itemprop="image" itemscope="" itemtype="http://schema.org/ImageObject"
 				data-image="<?= $previewUrl; ?>"
 				<?= $getVariantData( $mediaItem ); ?> >
 				<a href="<?= $enc->attr( $mediaUrl ); ?>" itemprop="contentUrl"></a>

--- a/client/html/templates/catalog/detail/image-partial-standard.php
+++ b/client/html/templates/catalog/detail/image-partial-standard.php
@@ -46,7 +46,7 @@ $mediaItems = $this->get( 'mediaItems', [] );
 
 			<figure id="image-<?= $enc->attr( $id ); ?>"
 				class="item" style="background-image: url('<?= $mediaUrl; ?>')"
-				itemprop="associatedMedia" itemscope="" itemtype="http://schema.org/ImageObject"
+				itemprop="image" itemscope="" itemtype="http://schema.org/ImageObject"
 				data-image="<?= $previewUrl; ?>"
 				<?= $getVariantData( $mediaItem ); ?> >
 				<a href="<?= $enc->attr( $mediaUrl ); ?>" itemprop="contentUrl"></a>


### PR DESCRIPTION
Hi, 

according to http://schema.org/Product Product cannot have "associatedMedia" but can have "image".

[Google's test tool](https://search.google.com/structured-data/testing-tool/u/0/#url=https%3A%2F%2Fwww.interfahnen.com%2Fbeachflag-premium%2Fprodukt%2Fbend-premium%2F) is happy with that.