### PR TITLE
Bug in some ajax requests

### DIFF
--- a/client/html/themes/aimeos.js
+++ b/client/html/themes/aimeos.js
@@ -891,6 +891,7 @@ AimeosCatalog = {
 
 			$.ajax({
 				url: $(this).attr("href"),
+				dataType: 'html',
 				headers: {
 					"X-Requested-With": "jQuery"
 				}
@@ -923,6 +924,7 @@ AimeosCatalog = {
 
 			$.ajax({
 				url: $(this).attr("href"),
+				dataType: 'html',
 				headers: {
 					"X-Requested-With": "jQuery"
 				}


### PR DESCRIPTION
In some environments the ajax calls setupWatchAction and setupFavoriteAction do not work! Added missing html dataType.