### PR TITLE
Stop page scroll jumping on product detail images

### DIFF
--- a/client/html/themes/aimeos-detail.js
+++ b/client/html/themes/aimeos-detail.js
@@ -33,9 +33,6 @@ d.slice(e-c+1,e+c+2).addClass("slick-active").attr("aria-hidden","false")),0===a
  */
 AimeosCatalogDetail = {
 
-	OFFSET: ($(".catalog-detail-image").offset() || {top: 0}).top,
-
-
 	/**
 	 * Initializes the slider for the thumbnail gallery (small images)
 	 */

--- a/client/html/themes/aimeos-detail.js
+++ b/client/html/themes/aimeos-detail.js
@@ -61,11 +61,12 @@ AimeosCatalogDetail = {
 
 		$(".catalog-detail-image").on("click", ".thumbs .item", {}, function(ev) {
 
+			var scrollPosition = document.documentElement.scrollTop;
 			$(".thumbs .item", ev.delegateTarget).removeClass("selected");
 			$(this).addClass("selected");
-
+			
 			window.location = $(this).attr("href");
-			window.scroll(0, AimeosCatalogDetail.OFFSET);
+			window.scroll(0, scrollPosition);
 
 			return false;
 		});


### PR DESCRIPTION
Added the scrollPosition variable to save the current page scroll location before the href is changed, then changed the window.scroll to go to that height instead of the AimeosCatalogDetail.OFFSET.