### PR TITLE
Infinite scrolling

### DIFF
--- a/client/html/templates/catalog/lists/items-body-standard.php
+++ b/client/html/templates/catalog/lists/items-body-standard.php
@@ -27,11 +27,28 @@ $enc = $this->encoder();
  * @category User
  * @see client/html/catalog/domains
  */
+$listTarget = $this->config( 'client/html/catalog/lists/url/target' );
+$listController = $this->config( 'client/html/catalog/lists/url/controller', 'catalog' );
+$listAction = $this->config( 'client/html/catalog/lists/url/action', 'list' );
+$listConfig = $this->config( 'client/html/catalog/lists/url/config', [] );
+$listParams = $this->get( 'listParams', [] );
 
+/** client/html/catalog/lists/infinite-scroll
+ * Enables infinite scrolling in product catalog list
+ *
+ * If set to true, products from the next page are loaded via XHR request
+ * and added to the product list when the user reaches the list bottom.
+ *
+ * @param boolean True to use infinite scrolling, false to fisable it
+ * @since 2018.10
+ * @category Developer
+ */
+$infiniteScroll = $this->config( 'client/html/catalog/lists/infinite-scroll', false );
 
+$infiniteUrl = ( $infiniteScroll && $this->get( 'listPageNext', 0 ) > $this->get( 'listPageCurr', 0 ) ) ? $this->url( $listTarget, $listController, $listAction, array( 'l_page' => $this->get( 'listPageNext' ) ) + $listParams, [], $listConfig + array( 'absoluteUri' => true ) ) : '';
 ?>
 <?php $this->block()->start( 'catalog/lists/items' ); ?>
-<div class="catalog-list-items">
+<div class="catalog-list-items" data-infinite-url="<?= $infiniteUrl ?>">
 
 	<?= $this->partial(
 		$this->config( 'client/html/common/partials/products', 'common/partials/products-standard.php' ),

--- a/client/html/templates/catalog/lists/items-body-standard.php
+++ b/client/html/templates/catalog/lists/items-body-standard.php
@@ -39,13 +39,13 @@ $listParams = $this->get( 'listParams', [] );
  * If set to true, products from the next page are loaded via XHR request
  * and added to the product list when the user reaches the list bottom.
  *
- * @param boolean True to use infinite scrolling, false to fisable it
- * @since 2018.10
+ * @param boolean True to use infinite scrolling, false to disable it
+ * @since 2019.10
  * @category Developer
  */
 $infiniteScroll = $this->config( 'client/html/catalog/lists/infinite-scroll', false );
 
-$infiniteUrl = ( $infiniteScroll && $this->get( 'listPageNext', 0 ) > $this->get( 'listPageCurr', 0 ) ) ? $this->url( $listTarget, $listController, $listAction, array( 'l_page' => $this->get( 'listPageNext' ) ) + $listParams, [], $listConfig + array( 'absoluteUri' => true ) ) : '';
+$infiniteUrl = ( $infiniteScroll && $this->get( 'listPageNext', 0 ) > $this->get( 'listPageCurr', 0 ) ) ? $this->url( $listTarget, $listController, $listAction, array( 'l_page' => $this->get( 'listPageNext' ) ) + $listParams, [], $listConfig ) : '';
 ?>
 <?php $this->block()->start( 'catalog/lists/items' ); ?>
 <div class="catalog-list-items" data-infinite-url="<?= $infiniteUrl ?>">

--- a/client/html/tests/Client/Html/Catalog/Lists/Items/StandardTest.php
+++ b/client/html/tests/Client/Html/Catalog/Lists/Items/StandardTest.php
@@ -73,7 +73,7 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 
 		$output = $this->object->getBody();
 
-		$this->assertStringStartsWith( '<div class="catalog-list-items">', $output );
+		$this->assertStringStartsWith( '<div class="catalog-list-items"', $output );
 
 		$this->assertContains( '<div class="price-item', $output );
 		$this->assertContains( '<span class="quantity"', $output );

--- a/client/html/themes/aimeos.js
+++ b/client/html/themes/aimeos.js
@@ -1232,10 +1232,39 @@ AimeosCatalogList = {
 
 
 	/**
+	 * Enables infinite scroll if available
+	 */
+	setupInfiniteScroll: function() {
+		if( $('.catalog-list-items').data('infinite-url') != '') {
+			$(window).on( 'scroll', function() {
+				var infiniteUrl = $('.catalog-list-items').data('infinite-url');
+				
+				if( infiniteUrl != '' && $('.catalog-list-items')[0].getBoundingClientRect().bottom - $(window).height() < 50 ) {
+					$('.catalog-list-items').data('infinite-url', '');
+					
+					$.ajax({
+						url: infiniteUrl
+					}).then( function( response ) {             
+						var nextPage = $( response );
+						nextPage.find('.catalog-list-items ul li').each( function() {
+							$('.catalog-list-items ul').append(this);
+						});
+						var nextUrl = nextPage.find('.catalog-list-items').data( 'infinite-url' );
+						$('.catalog-list-items').data('infinite-url', nextUrl);
+						$(window).trigger('scroll');
+					});
+				}
+			});
+		}
+	},
+
+
+	/**
 	 * Initializes the catalog list actions
 	 */
 	init: function() {
 		this.setupImageSwitch();
+		this.setupInfiniteScroll();
 	}
 };
 

--- a/client/html/themes/aimeos.js
+++ b/client/html/themes/aimeos.js
@@ -1244,7 +1244,7 @@ AimeosCatalogList = {
 					
 					$.ajax({
 						url: infiniteUrl
-					}).then( function( response ) {             
+					}).done( function( response ) {             
 						var nextPage = $( response );
 						nextPage.find('.catalog-list-items ul li').each( function() {
 							$('.catalog-list-items ul').append(this);
@@ -1252,6 +1252,8 @@ AimeosCatalogList = {
 						var nextUrl = nextPage.find('.catalog-list-items').data( 'infinite-url' );
 						$('.catalog-list-items').data('infinite-url', nextUrl);
 						$(window).trigger('scroll');
+					}).fail( function() {
+						$('.catalog-list-items').data('infinite-url', infiniteUrl);
 					});
 				}
 			});


### PR DESCRIPTION
Adds an option to enable infinite scrolling, see #83. Downwards compatible, as per default no infinite scrolling URLs are generated and thus the JS is not activated.