### PR TITLE
Bugfix: Dont fetch mini basket data without JSON url

### DIFF
--- a/client/html/themes/aimeos.js
+++ b/client/html/themes/aimeos.js
@@ -386,7 +386,13 @@ AimeosBasketMini = {
 	 */
 	update: function() {
 
-		$.ajax($(".aimeos.basket-mini[data-jsonurl]").data("jsonurl"), {
+		var jsonurl = $(".aimeos.basket-mini[data-jsonurl]").data("jsonurl");
+
+		if( typeof jsonurl === 'undefined' ) {
+			return;
+		}
+
+		$.ajax(jsonurl, {
 			"method": "OPTIONS",
 			"dataType": "json"
 		}).then(function(options) {

--- a/client/html/themes/aimeos.js
+++ b/client/html/themes/aimeos.js
@@ -388,7 +388,7 @@ AimeosBasketMini = {
 
 		var jsonurl = $(".aimeos.basket-mini[data-jsonurl]").data("jsonurl");
 
-		if(jsonurl === 'undefined' || jsonurl == '') {
+		if(typeof jsonurl === 'undefined' || jsonurl == '') {
 			return;
 		}
 

--- a/client/html/themes/aimeos.js
+++ b/client/html/themes/aimeos.js
@@ -388,7 +388,7 @@ AimeosBasketMini = {
 
 		var jsonurl = $(".aimeos.basket-mini[data-jsonurl]").data("jsonurl");
 
-		if( typeof jsonurl === 'undefined' ) {
+		if(jsonurl === 'undefined' || jsonurl == '') {
 			return;
 		}
 


### PR DESCRIPTION
Currently, the `AimeosBasketMini->update()` function starts a JSON request every time the basket is updated. When no mini basket is available (leading to an undefined JSON url), a JSON call with the current URL is performed instead. This can result in unexpected behaviour, because the current URL is requested and fetched for a second time.

This patch requires an available mini basket JSON url, the call is not performed otherwise.