### PR TITLE
Regression fix: Infinite scrolling

### DIFF
--- a/client/html/themes/aimeos.js
+++ b/client/html/themes/aimeos.js
@@ -1251,7 +1251,7 @@ AimeosCatalogList = {
 				var list = $('.catalog-list-items').first();
 				var infiniteUrl = list.data('infinite-url');
 
-				if(infiniteUrl && list.getBoundingClientRect().bottom - $(window).height() < 50) {
+				if(infiniteUrl && list[0].getBoundingClientRect().bottom - $(window).height() < 50) {
 
 					list.data('infinite-url', '');
 


### PR DESCRIPTION
Infinite scrolling was broken after latest refactoring, because the native JS method `getBoundingClientRect()` was called on a jQuery object.