### PR TITLE
Provide background-color for Safari

### DIFF
--- a/client/html/themes/elegance/aimeos.css
+++ b/client/html/themes/elegance/aimeos.css
@@ -106,6 +106,7 @@
 
 .aimeos input:disabled {
 	border-color: #D0D0D0;
+	background-color: #eee;
 }
 
 .aimeos .minibutton {


### PR DESCRIPTION
Other browsers set the background of a disabled input field to grey. Safari doesn't, therefore, you have to provide the background-color. Change the #eee; to any other grey which fits into the theme.