### PR TITLE
[FIX] W3C <input>

### DIFF
--- a/client/html/templates/catalog/detail/body-standard.php
+++ b/client/html/templates/catalog/detail/body-standard.php
@@ -306,7 +306,7 @@ $reqstock = (int) $this->config( 'client/html/basket/require-stock', true );
 										<input type="number" class="form-control input-lg" <?= !$this->detailProductItem->isAvailable() ? 'disabled' : '' ?>
 											name="<?= $enc->attr( $this->formparam( ['b_prod', 0, 'quantity'] ) ) ?>"
 											min="<?= $this->detailProductItem->getScale() ?>" max="2147483647"
-											step="<?= $this->detailProductItem->getScale() ?>" maxlength="10"
+											step="<?= $this->detailProductItem->getScale() ?>"
 											value="<?= $this->detailProductItem->getScale() ?>" required="required"
 										>
 									<?php endif ?>


### PR DESCRIPTION
Attribute maxlength is only allowed when the input type is email, password, search, tel, text, or url.