### PR TITLE
Redirect to confirmation page when total is zero

### DIFF
--- a/client/html/src/Client/Html/Checkout/Standard/Process/Standard.php
+++ b/client/html/src/Client/Html/Checkout/Standard/Process/Standard.php
@@ -282,17 +282,11 @@ class Standard
 
 			if( ( $form = $this->processPayment( $basket, $orderItem ) ) === null )
 			{
-				$args = array();
-
 				$services = $basket->getService( \Aimeos\MShop\Order\Item\Base\Service\Base::TYPE_PAYMENT );
-
-				if( ( $service = reset( $services ) ) !== false )
-				{
-					$args = array( 'code' => $service->getCode() );
-				}
+				$args = ( $service = reset( $services ) ) ? ['code' => $service->getCode()] : [];
 
 				$orderCntl->save( $orderItem->setPaymentStatus( \Aimeos\MShop\Order\Item\Base::PAY_AUTHORIZED ) );
-				$view->standardUrlNext = $this->getUrlConfirm( $view, $args, [] );
+				$view->standardUrlNext = $this->getUrlConfirm( $view, $args, ['absoluteUri' => true] );
 				$view->standardMethod = 'POST';
 			}
 			else // no payment service available
@@ -396,8 +390,8 @@ class Standard
 			$args = array( 'code' => $service->getCode() );
 			$urls = array(
 				'payment.url-self' => $this->getUrlSelf( $view, ['c_step' => 'process'], [] ),
-				'payment.url-update' => $this->getUrlUpdate( $view, $args + ['orderid' => $orderItem->getId()], [] ),
-				'payment.url-success' => $this->getUrlConfirm( $view, $args, [] ),
+				'payment.url-update' => $this->getUrlUpdate( $view, $args + ['orderid' => $orderItem->getId()], ['absoluteUri' => true] ),
+				'payment.url-success' => $this->getUrlConfirm( $view, $args, ['absoluteUri' => true] ),
 			);
 
 			$params = $view->param();

--- a/client/html/src/Client/Html/Checkout/Standard/Process/Standard.php
+++ b/client/html/src/Client/Html/Checkout/Standard/Process/Standard.php
@@ -287,17 +287,13 @@ class Standard
 
 				$services = $basket->getService( \Aimeos\MShop\Order\Item\Base\Service\Base::TYPE_PAYMENT );
 
-				$paymentstatus = $context->getConfig()->get('client/html/checkout/standard/process/zero-total-payment-status',
-					\Aimeos\MShop\Order\Item\Base::PAY_AUTHORIZED
-				);
-
 				if( ( $service = reset( $services ) ) !== false )
 				{
 					$args = array( 'code' => $service->getCode() );
 					$config = array( 'absoluteUri' => true, 'namespace' => false );
 				}
 
-				$orderCntl->save( $orderItem->setPaymentStatus( $paymentstatus ) );
+				$orderCntl->save( $orderItem->setPaymentStatus( \Aimeos\MShop\Order\Item\Base::PAY_AUTHORIZED ) );
 				$view->standardUrlNext = $this->getUrlConfirm( $view, $args, $config );
 				$view->standardMethod = 'POST';
 			}

--- a/client/html/src/Client/Html/Checkout/Standard/Process/Standard.php
+++ b/client/html/src/Client/Html/Checkout/Standard/Process/Standard.php
@@ -283,18 +283,16 @@ class Standard
 			if( ( $form = $this->processPayment( $basket, $orderItem ) ) === null )
 			{
 				$args = array();
-				$config = array();
 
 				$services = $basket->getService( \Aimeos\MShop\Order\Item\Base\Service\Base::TYPE_PAYMENT );
 
 				if( ( $service = reset( $services ) ) !== false )
 				{
 					$args = array( 'code' => $service->getCode() );
-					$config = array( 'absoluteUri' => true, 'namespace' => false );
 				}
 
 				$orderCntl->save( $orderItem->setPaymentStatus( \Aimeos\MShop\Order\Item\Base::PAY_AUTHORIZED ) );
-				$view->standardUrlNext = $this->getUrlConfirm( $view, $args, $config );
+				$view->standardUrlNext = $this->getUrlConfirm( $view, $args, [] );
 				$view->standardMethod = 'POST';
 			}
 			else // no payment service available
@@ -396,11 +394,10 @@ class Standard
 		if( ( $service = reset( $services ) ) !== false )
 		{
 			$args = array( 'code' => $service->getCode() );
-			$config = array( 'absoluteUri' => true, 'namespace' => false );
 			$urls = array(
 				'payment.url-self' => $this->getUrlSelf( $view, ['c_step' => 'process'], [] ),
-				'payment.url-update' => $this->getUrlUpdate( $view, $args + ['orderid' => $orderItem->getId()], $config ),
-				'payment.url-success' => $this->getUrlConfirm( $view, $args, $config ),
+				'payment.url-update' => $this->getUrlUpdate( $view, $args + ['orderid' => $orderItem->getId()], [] ),
+				'payment.url-success' => $this->getUrlConfirm( $view, $args, [] ),
 			);
 
 			$params = $view->param();

--- a/client/html/src/Client/Html/Checkout/Standard/Process/Standard.php
+++ b/client/html/src/Client/Html/Checkout/Standard/Process/Standard.php
@@ -287,13 +287,17 @@ class Standard
 
 				$services = $basket->getService( \Aimeos\MShop\Order\Item\Base\Service\Base::TYPE_PAYMENT );
 
+				$paymentstatus = $context->getConfig()->get('client/html/checkout/standard/process/zero-total-payment-status',
+					\Aimeos\MShop\Order\Item\Base::PAY_AUTHORIZED
+				);
+
 				if( ( $service = reset( $services ) ) !== false )
 				{
 					$args = array( 'code' => $service->getCode() );
 					$config = array( 'absoluteUri' => true, 'namespace' => false );
 				}
 
-				$orderCntl->save( $orderItem->setPaymentStatus( \Aimeos\MShop\Order\Item\Base::PAY_AUTHORIZED ) );
+				$orderCntl->save( $orderItem->setPaymentStatus( $paymentstatus ) );
 				$view->standardUrlNext = $this->getUrlConfirm( $view, $args, $config );
 				$view->standardMethod = 'POST';
 			}

--- a/client/html/src/Client/Html/Checkout/Standard/Process/Standard.php
+++ b/client/html/src/Client/Html/Checkout/Standard/Process/Standard.php
@@ -282,8 +282,19 @@ class Standard
 
 			if( ( $form = $this->processPayment( $basket, $orderItem ) ) === null )
 			{
+				$args = array();
+				$config = array();
+
+				$services = $basket->getService( \Aimeos\MShop\Order\Item\Base\Service\Base::TYPE_PAYMENT );
+
+				if( ( $service = reset( $services ) ) !== false )
+				{
+					$args = array( 'code' => $service->getCode() );
+					$config = array( 'absoluteUri' => true, 'namespace' => false );
+				}
+
 				$orderCntl->save( $orderItem->setPaymentStatus( \Aimeos\MShop\Order\Item\Base::PAY_AUTHORIZED ) );
-				$view->standardUrlNext = $this->getUrlConfirm( $view, [], [] );
+				$view->standardUrlNext = $this->getUrlConfirm( $view, $args, $config );
 				$view->standardMethod = 'POST';
 			}
 			else // no payment service available


### PR DESCRIPTION
This pull requests introduces changes discussed on the following thread in the forum.

https://aimeos.org/help/help-f15/payment-service-process-not-being-called-t3717.html

1. Make the default payment status of a zero total order configurable. 

If a payment has been processed with a zero total then we have the option to set the status to anything other than authorised.

My particular use case is that I wish for it be received, although now writing this im questioning it myself :)

2. In order to handle payments post processing of a zero total we need to send through the service code to the confirmation page.

As discussed on this thread I understand  this is a breaking change, some service providers expect data to be present in the request sent to the confirmation page. eg. PayPal. With this update this is likely to throw exceptions.

I don't know how you group updates across repos that are related, so for now the changes are only within this repository.

Perhaps also I should check the configurable value for the delivery status assignment...I notice there is a `checkDeliveryStatus` method on the `$orderItem` that we can use to validate this.