### PR TITLE
Fix infinite scroll lazy-image loading

### DIFF
--- a/client/html/themes/default/aimeos.js
+++ b/client/html/themes/default/aimeos.js
@@ -1809,6 +1809,7 @@ AimeosCatalogList = {
 
 						$('ul.list-items', list).append(nextPage.find('.catalog-list-items ul.list-items li.product'));
 						list.data('infinite-url', nextUrl);
+						Aimeos.loadImages();
 						$(window).trigger('scroll');
 					});
 				}


### PR DESCRIPTION
In Aimeos 2018.10, window.scroll() triggered re-initialization of lazy images. In later versions, the newly added DOM elements have to be initialized manually.