### PR TITLE
Prevent invalid URL generation

### DIFF
--- a/client/html/src/Client/Html/Basket/Standard/Standard.php
+++ b/client/html/src/Client/Html/Basket/Standard/Standard.php
@@ -400,7 +400,7 @@ class Standard
 			$config = $view->config( 'client/html/catalog/lists/url/config', [] );
 		}
 
-		if( empty( $params ) === false ) {
+		if( empty( $params ) === false && $params['f_name'] && $params['f_catid'] > 0 ) {
 			$view->standardBackUrl = $view->url( $target, $controller, $action, $params, [], $config );
 		}
 


### PR DESCRIPTION
In some cases, `$params = $context->getSession()->get( 'aimeos/catalog/lists/params/last/' . $site` results in an invalid `$params` array, e.g. `$params['f_name']` set to `null`. 

This leads to failing URL generation and in Typo3 to an exception in the framework. The underlaying problem might be cache related, but I'm not sure. However - better fix the symptoms then doing nothing, right? :-)