### PR TITLE
Prevent invalid URL generation

### DIFF
--- a/client/html/src/Client/Html/Basket/Standard/Standard.php
+++ b/client/html/src/Client/Html/Basket/Standard/Standard.php
@@ -401,13 +401,7 @@ class Standard
 		}
 
 		if( empty( $params ) === false ) {
-			foreach( $params as $key => $val ) {
-				if( is_null( $val ) ) {
-					unset( $params[$key] );
-				}
-			}
-
-			$view->standardBackUrl = $view->url( $target, $controller, $action, $params, [], $config );
+			$view->standardBackUrl = $view->url( $target, $controller, $action, array_filter( $params ), [], $config );
 		}
 
 		$basket = \Aimeos\Controller\Frontend::create( $this->getContext(), 'basket' )->get();

--- a/client/html/src/Client/Html/Basket/Standard/Standard.php
+++ b/client/html/src/Client/Html/Basket/Standard/Standard.php
@@ -401,6 +401,12 @@ class Standard
 		}
 
 		if( empty( $params ) === false ) {
+			foreach( $params as $key => $val ) {
+				if( is_null( $val ) ) {
+					unset( $params[$key] );
+				}
+			}
+
 			$view->standardBackUrl = $view->url( $target, $controller, $action, $params, [], $config );
 		}
 


### PR DESCRIPTION
Another one for https://github.com/aimeos/ai-client-html/pull/157

Typo3 RouteEnhancer defaults are not used as long as the parameter is available (even if empty or `null`).