### PR TITLE
Remove slice() from stockItemsByProducts

### DIFF
--- a/src/Client/Html/Catalog/Stock/Standard.php
+++ b/src/Client/Html/Catalog/Stock/Standard.php
@@ -95,7 +95,6 @@ class Standard
 		$view->stockProductIds = $prodIds;
 		$view->stockItemsByProducts = \Aimeos\Controller\Frontend::create( $context, 'stock' )
 			->product( $prodIds )->type( $type )->sort( $sort )
-			->slice( 0, count( $prodIds ) )
 			->search()
 			->groupBy( 'stock.productid' );
 


### PR DESCRIPTION
Remove slice() from stockItemsByProducts so that all stock types are retrieved for each product.