### PR TITLE
Only show as out of stock if all stock types are out of stock

### DIFF
--- a/themes/client/html/default/aimeos.js
+++ b/themes/client/html/default/aimeos.js
@@ -562,7 +562,7 @@ AimeosBasket = {
 		$(".articleitem", item).removeClass("price-actual");
 		newPrice.addClass("price-actual");
 
-		if(!(item.data("reqstock") && $(".stockitem", newStock).hasClass("stock-out"))) {
+		if(!(item.data("reqstock") && $(".stockitem", newStock).filter(".stock-out").length == $(".stockitem", newStock).length)) {
 			stock = true;
 		}
 


### PR DESCRIPTION
Only show products as out of stock if all stock types are out of stock.

Previously, if any of the stock types were out of stock then the product would appear out of stock and the add to cart button was disabled even if there was one stock type that still had stock.