### PR TITLE
Call a variant in a selection article directly

### DIFF
--- a/templates/client/html/catalog/detail/body.php
+++ b/templates/client/html/catalog/detail/body.php
@@ -620,3 +620,30 @@ $reqstock = (int) $this->config( 'client/html/basket/require-stock', true );
 	</div>
 
 <?php endif ?>
+
+<?php
+// preselection of a variant in a selection article
+if (isset($_GET['productId']) && is_numeric($_GET['productId'])):
+
+    foreach( $this->detailProductItem->getRefItems( 'product', null, 'default' ) as $prodid => $product ) :
+
+        if ($prodid == $_GET['productId']):
+
+            $attributes = $product->getRefItems('attribute',null,'variant');
+            $js = '';
+            foreach($attributes as $attribId => $attribute):
+                $js .= '"' .  $attribute->getType() . '": "' . $attribute->getId() . '",
+                ';
+            endforeach;
+
+            if (!empty($js)): ?>
+               <script>
+                   AimeosVariantSelectionProduct = {"prodId": "<?= $this->detailProductItem->getId() ?>", "attributes": {<?= $js ?>}};
+               </script>
+
+            <?php endif;
+        endif;
+    endforeach;
+endif;
+
+?>

--- a/templates/client/html/catalog/detail/body.php
+++ b/templates/client/html/catalog/detail/body.php
@@ -52,15 +52,11 @@ $reqstock = (int) $this->config( 'client/html/basket/require-stock', true );
 
         // preselection of a variant product in a selection article
         $preSelectVariantAttributes = [];
-        if ($this->param( 'productId' ) && is_numeric($this->param( 'productId' ))):
+        if ($this->param( 'productId' )):
 
-            if(($listItem = $this->detailProductItem->getListItem( 'product', 'default', (int) $this->param( 'productId' ))) && ( $product = $listItem->getRefItem() ) )
-
-                    $attributes = $product->getRefItems('attribute',null,'variant');
-
-                    foreach($attributes as $attribId => $attribute):
-                        $preSelectVariantAttributes[$attribute->getType()] =  $attribute->getId();
-                    endforeach;
+            if(($listItem = $this->detailProductItem->getListItem( 'product', 'default', $this->param( 'productId' ))) && ( $product = $listItem->getRefItem() ) ):
+                 $preSelectVariantAttributes = $product->getRefItems( 'attribute', null, 'variant' )->col( 'attribute.id', 'attribute.type' );
+            endif;
 
         endif;
 

--- a/templates/client/html/catalog/detail/body.php
+++ b/templates/client/html/catalog/detail/body.php
@@ -51,20 +51,16 @@ $reqstock = (int) $this->config( 'client/html/basket/require-stock', true );
 <?php if( isset( $this->detailProductItem ) ) : 
 
         // preselection of a variant product in a selection article
-        $preSelectVariantAttributes = [];
-        if ($_GET['productId'] && is_numeric($_GET['productId'])):
+        $preSelectVariantAttributes = '';
+        if ($this->param( 'productId' ) && is_numeric($this->param( 'productId' ))):
 
-            if(($listItem = $this->detailProductItem->getListItem( 'product', 'default', (int) $_GET['productId'] ) ) && ( $product = $listItem->getRefItem() ) )
+            if(($listItem = $this->detailProductItem->getListItem( 'product', 'default', (int) $this->param( 'productId' ))) && ( $product = $listItem->getRefItem() ) )
 
                     $attributes = $product->getRefItems('attribute',null,'variant');
 
                     foreach($attributes as $attribId => $attribute):
                         $preSelectVariantAttributes[$attribute->getType()] =  $attribute->getId();
                     endforeach;
-
-                    if (!empty($preSelectVariantAttributes)):
-                        $preSelectVariantAttributes = htmlspecialchars(json_encode(['attributes' => $preSelectVariantAttributes, 'prodId' => $this->detailProductItem->getId()]), ENT_QUOTES, 'UTF-8');
-                    endif;
 
         endif;
 
@@ -79,7 +75,7 @@ $reqstock = (int) $this->config( 'client/html/basket/require-stock', true );
 
 			<article class="product row <?= $this->detailProductItem->getConfigValue( 'css-class' ) ?>"
 				data-id="<?= $this->detailProductItem->getId() ?>" data-reqstock="<?= $reqstock ?>"
-				<?= !empty($preSelectVariantAttributes) ? 'data-preselectvariant="' . $preSelectVariantAttributes . '"' : '' ?>>
+				data-preselectvariant="<?= $enc->attr($preSelectVariantAttributes)?>"
 
 				<div class="col-sm-6">
 

--- a/templates/client/html/catalog/detail/body.php
+++ b/templates/client/html/catalog/detail/body.php
@@ -51,7 +51,7 @@ $reqstock = (int) $this->config( 'client/html/basket/require-stock', true );
 <?php if( isset( $this->detailProductItem ) ) : 
 
         // preselection of a variant product in a selection article
-        $preSelectVariantAttributes = '';
+        $preSelectVariantAttributes = [];
         if ($this->param( 'productId' ) && is_numeric($this->param( 'productId' ))):
 
             if(($listItem = $this->detailProductItem->getListItem( 'product', 'default', (int) $this->param( 'productId' ))) && ( $product = $listItem->getRefItem() ) )

--- a/themes/client/html/default/aimeos.js
+++ b/themes/client/html/default/aimeos.js
@@ -446,15 +446,11 @@ AimeosBasket = {
 	 */
 	checkPreselectionVariant() {
 
-		if (typeof AimeosVariantSelectionProduct == 'object') {
-
-			$(AimeosVariantSelectionProduct).each(function() {
-				const prodId = this.prodId;
-				$.each(this.attributes, function(key,val){
-					$('#select-' + prodId + '-' + key).val(val).trigger('change');
-				});
-			});
-
+		if ($('article.product.row').data('preselectvariant')) {
+		       let preSelected = $('article.product.row').data('preselectvariant');
+		       $.each(preSelected.attributes, function (key, val) {
+			   $('#select-' + preSelected.prodId + '-' + key).val(val).trigger('change');
+		       });
 		}
 	},
 

--- a/themes/client/html/default/aimeos.js
+++ b/themes/client/html/default/aimeos.js
@@ -446,10 +446,10 @@ AimeosBasket = {
 	 */
 	checkPreselectionVariant() {
 
-		if ($('article.product.row').data('preselectvariant')) {
-		       let preSelected = $('article.product.row').data('preselectvariant');
-		       $.each(preSelected.attributes, function (key, val) {
-			   $('#select-' + preSelected.prodId + '-' + key).val(val).trigger('change');
+		const product = $('article.product');
+		if (product && product.data('preselectvariant')) {
+		       $.each(product.data('preselectvariant'), function (key, val) {
+			   $('#select-' + product.data('id') + '-' + key).val(val).trigger('change');
 		       });
 		}
 	},

--- a/themes/client/html/default/aimeos.js
+++ b/themes/client/html/default/aimeos.js
@@ -441,6 +441,23 @@ AimeosBasket = {
 		});
 	},
 
+	/**
+	 * Check for variants in URL (productId = variant-product-Id), set the variant attributes and trigger select-dropdown´s to show the variant product
+	 */
+	checkPreselectionVariant() {
+
+		if (typeof AimeosVariantSelectionProduct == 'object') {
+
+			$(AimeosVariantSelectionProduct).each(function() {
+				const prodId = this.prodId;
+				$.each(this.attributes, function(key,val){
+					$('#select-' + prodId + '-' + key).val(val).trigger('change');
+				});
+			});
+
+		}
+	},
+
 
 	/**
 	 * Shows the images associated to the variant attributes
@@ -684,4 +701,6 @@ $(function() {
 	AimeosCatalog.init();
 
 	Aimeos.loadImages();
+	
+	AimeosCatalog.checkPreselectionVariant();
 });


### PR DESCRIPTION
It should be possible to preselect a variant in a selection article directly with a URL-Param e.g. "productId".
Maybe a use case is a product feed for various tag managers like google tag manager to expose all the variant products of a selection product.
