### PR TITLE
[Bugfix] Typo in option-partial.php

### DIFF
--- a/templates/client/html/checkout/standard/option-partial.php
+++ b/templates/client/html/checkout/standard/option-partial.php
@@ -206,7 +206,7 @@
 	<div class="checkout-standard-summary-option-account col-sm-12">
 		<h3><?= $enc->html( $this->translate( 'client', 'Customer account' ), $enc::TRUST ) ?></h3>
 
-		<div class="single <?= !$this->value( $this->get( 'error', [] ), 'option/account' ) ?: 'error' ?>">
+		<div class="single <?= !$this->value( $this->get( 'errors', [] ), 'option/account' ) ?: 'error' ?>">
 			<input id="option-account" type="checkbox" value="1"
 				name="<?= $enc->attr( $this->formparam( array( 'cs_option_account' ) ) ) ?>"
 				<?= ( $this->param( 'cs_option_account', 1 ) == 1 ? 'checked="checked"' : '' ) ?>
@@ -223,7 +223,7 @@
 <div class="checkout-standard-summary-option-terms col-sm-12">
 	<h3><?= $enc->html( $this->translate( 'client', 'Terms and conditions' ), $enc::TRUST ) ?></h3>
 
-	<div class="single <?= !$this->value( $this->get( 'error', [] ), 'option/terms' ) ?: 'error' ?>">
+	<div class="single <?= !$this->value( $this->get( 'errors', [] ), 'option/terms' ) ?: 'error' ?>">
 		<input type="hidden" name="<?= $enc->attr( $this->formparam( array( 'cs_option_terms' ) ) ) ?>" value="1">
 		<input id="option-terms-accept" type="checkbox" value="1"
 			name="<?= $enc->attr( $this->formparam( array( 'cs_option_terms_value' ) ) ) ?>"


### PR DESCRIPTION
Missing 's' to get the errors array.
Fix for #195 