### PR TITLE
Fix no view available issue when validating fields

### DIFF
--- a/src/Client/Html/Checkout/Standard/Address/Billing/Standard.php
+++ b/src/Client/Html/Checkout/Standard/Address/Billing/Standard.php
@@ -469,7 +469,7 @@ class Standard
 			$params = $view->param( 'ca_billing', [] );
 
 			if( ( $view->addressBillingError = $this->checkFields( $params ) ) !== [] ) {
-				throw new \Aimeos\Client\Html\Exception( sprintf( 'At least one billing address part is missing or invalid' ) );
+				return false;
 			}
 		}
 		else // existing address
@@ -477,7 +477,7 @@ class Standard
 			$params = $view->param( 'ca_billing_' . $option, [] ) + $view->param( 'ca_extra', [] );
 
 			if( !empty( $params ) && ( $view->addressBillingError = $this->checkFields( $params ) ) !== [] ) {
-				throw new \Aimeos\Client\Html\Exception( sprintf( 'At least one billing address part is missing or invalid' ) );
+				return false;
 			}
 
 			$cntl = \Aimeos\Controller\Frontend::create( $context, 'customer' )->uses( [] );


### PR DESCRIPTION
Hello Aimeos, 

I have added validation for the phone field in client.php of my theme:
![image](https://user-images.githubusercontent.com/42222569/220826515-5980fde8-03e5-4b89-aa1b-b71431b554bc.png)

When I do a test and intentionally put an incorrect value in the telephone to validate that the rule that I put in the configuration works, it redirects me to a page without content and the error appears: **No view available.**
![image](https://user-images.githubusercontent.com/42222569/220827648-9ff9b165-d8cc-46cf-ba6b-d00235fb4740.png)


This is caused by a throw new, which does not allow executing the init function where the view is set.

For it, I have replaced the _throw new_ with a _return false;_

Now when the validation fails, the page reloads and shows me correctly the field that has not passed the regex validation that I have configured.
![image](https://user-images.githubusercontent.com/42222569/220827307-314eff50-c927-4dfd-88c7-dbc12216938e.png)

I look forward to your comments,

Regards!
