### PR TITLE
Ensure key based loading order for decorators

### DIFF
--- a/src/Client/Html.php
+++ b/src/Client/Html.php
@@ -113,6 +113,7 @@ class Html
 				unset( $decorators[$key] );
 			}
 		}
+		ksort($decorators);
 
 		$classprefix = '\\Aimeos\\Client\\Html\\Common\\Decorator\\';
 		$client = self::addDecorators( $context, $client, $decorators, $classprefix );


### PR DESCRIPTION
Related to a typo3 bug with the calling order of decorators when a new key is set within a plugin.
https://github.com/aimeos/aimeos-typo3/issues/216