### PR TITLE
Require basket name to ensure saved baskets are visible

### DIFF
--- a/templates/client/html/basket/standard/body.php
+++ b/templates/client/html/basket/standard/body.php
@@ -26,6 +26,7 @@ $enc = $this->encoder();
 							<input class="form-control basket-name" type="text" maxlength="255"
 								placeholder="<?= $enc->attr( $this->translate( 'client', 'Basket name' ) ) ?>"
 								name="<?= $enc->attr( $this->formparam( 'b_name' ) ) ?>"
+								required
 							>
 							<button class="btn" type="submit"
 								formaction="<?= $enc->attr( $this->link( 'client/html/basket/standard/url', ['b_action' => 'save'] ) ) ?>">


### PR DESCRIPTION
When a logged-in user clicks the basket save icon, the basket is saved successfully. However, if no basket name is provided, the saved basket is not visible on the user account page. Requiring a basket name before saving would be the best solution